### PR TITLE
resolves #8 'paho.mqtt.client' has no attribute 'CallbackAPIVersion'

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ Let's assume you have an SD card for a Raspberry Pi 4 you'd like to Venusianize.
 
 ### A typical server
 
+* Use Debian >=13.
 * `git clone https://github.com/M-o-a-T/venusian.git /opt/venusian`
 * `cd /opt/venusian`
 * `./install -i /tmp/venus.img.gz -d /opt/venus -r /


### PR DESCRIPTION
Seems like doing backport work is silly on a project that's such a WIP.

Better to look forward!  