### PR TITLE
resolves #12 missing packages

### DIFF
--- a/install
+++ b/install
@@ -759,7 +759,7 @@ test -d "$R/usr/lib/python3/dist-packages/dbus_next" || I="$I python3-dbus-next"
 test -d "$R/usr/lib/python3/dist-packages/paho/mqtt" || I="$I python3-paho-mqtt"
 test -d "$R/usr/lib/python3/dist-packages/serial_asyncio" || I="$I python3-serial-asyncio"
 
-for P in lxml dbus pyudev pymodbus dnslib websockets click asyncclick asyncdbus yaml ; do
+for P in lxml dbus pyudev pymodbus dnslib websockets click asyncclick asyncdbus yaml attr outcome trio ; do
     test -d "$R/usr/lib/python3/dist-packages/$P" && continue
     I="$I python3-$P"
 done

--- a/install.d/fbset/README
+++ b/install.d/fbset/README
@@ -1,0 +1,1 @@
+Install fbset called from vnc 

--- a/install.d/fbset/pkg-r
+++ b/install.d/fbset/pkg-r
@@ -1,0 +1,1 @@
+test -s "$R/usr/bin/fbset" || I="$I fbset"


### PR DESCRIPTION
installs:

python3-attr
python3-outcome
python3-trio
fbset - called by VNC apparently

<code>
Mar 28 00:26:24 trixie start-gui.sh[164484]: /opt/venus/opt/victronenergy/gui/start-gui.sh: line 33: fbset: command not found
Mar 28 00:26:24 trixie start-gui.sh[164482]: VNC: driver not found
</code>

If we were headfull I don't think I'd be seeing the VNC driver error.