### PR TITLE
resolves #9 gui fails to start

### DIFF
--- a/install
+++ b/install
@@ -314,7 +314,7 @@ umask 022
 R="$(realpath "$root")"
 
 LIBVV=/var/lib/venusian
-USRV=/usr/lib/venusian/
+USRV=/usr/lib/venusian
 SERVICE="$USRV/service/"
 
 if [ ! -v MNT ] ; then
@@ -651,6 +651,7 @@ starters | while read f ; do
             echo >>$U ExecStart=/opt/victronenergy/dbus-mqtt/dbus_mqtt.py
             ;;
         (gui)
+            echo >>$U WorkingDirectory="/opt/victronenergy/gui"
             echo >>$U ExecStart="$USRV/bin/start-gui"
             ;;
         (*)

--- a/lib/bin/start-gui
+++ b/lib/bin/start-gui
@@ -3,10 +3,7 @@ exec 2>&1
 
 echo "*** Starting gui ***"
 
-export QT_QPA_PLATFORM=vnc:size=480x300:addr=127.0.0.1:port=$(expr 5900 + $SCREEN)
-export QT_PLUGIN_PATH=/v/u/lib/plugins
+export QT_PLUGIN_PATH=/v/u/lib/plugins,/usr/lib/venusian/opt/gui/gfxdrivers
 
-here=$(dirname $0)
-exec ${here}/gui
-
-
+here=`pwd`
+exec ${here}/gui -display "VNC:size=1095x684:depth=32:${SCREEN}"


### PR DESCRIPTION
This does 5 things:

- removes trailing slash from $USRV addressing file not found problem. Rest of <code>install</code> checked for impacts.
- adds WorkingDirectory to gui.service systemd unit definition so that <code>start-gui</code> believes it's in the same dir as <code>gui</code>
- changes <code>$here</code> variable in a way that works with WorkingDirectory (`pwd` in favor of <code>$0</code>)
- includes an additional directory to <code>QT_PLUGIN_PATH</code> that has the - most likely newest - QT vnc driver libqgfxvnc.so.
- adds necessary arguments to <code>gui</code> because PLATFORM environment variables have no effect possibly due to newer QT version or the way <code>gui</code> is compiled.  
