### PR TITLE
WIP: Look for libflashmq in /v/u instead of /usr

### DIFF
--- a/lib/bin/gen-flashmq-conf
+++ b/lib/bin/gen-flashmq-conf
@@ -14,7 +14,7 @@ thread_count 1
 max_packet_size 10240
 client_max_write_buffer_size 102400
 
-plugin /usr/libexec/flashmq/libflashmq-dbus-plugin.so
+plugin /v/u/libexec/flashmq/libflashmq-dbus-plugin.so
 expire_sessions_after_seconds 86400
 include_dir /run/user/${UID}/flashmq.d
 allow_anonymous true


### PR DESCRIPTION
*This is for discussion - Don't merge as-is*

My flashmq@venus doesn't start without this (exits with error code 99)

With it, it errors with exit code 1 due to the incompatible binary format (raspberry pi 5)
```
● flashmq.service - Per-User FlashMQ MQTT server
     Loaded: loaded (/var/lib/venusian/venus/.config/systemd/user/flashmq.service; enabled; preset: enabled)
     Active: activating (auto-restart) (Result: exit-code) since Mon 2025-11-10 15:22:06 MST; 1s ago
 Invocation: ae25324264ac43d6914498fdb845bd7a
    Process: 15077 ExecStartPre=/usr/lib/venusian/bin/gen-flashmq-conf (code=exited, status=0/SUCCESS)
    Process: 15082 ExecStart=/usr/bin/flashmq --config-file /run/user/107/flashmq.conf (code=exited, status=1/FAILURE)
   Main PID: 15082 (code=exited, status=1/FAILURE)
        CPU: 28ms

Nov 10 15:22:07 rpi flashmq[15117]: [2025-11-10 15:22:07.400] [NOTICE] [main] Creating IPv4 non-SSL websocket listener on [0.0>
Nov 10 15:22:07 rpi flashmq[15117]: [2025-11-10 15:22:07.400] [NOTICE] [main] Creating IPv6 non-SSL websocket listener on [::]>
Nov 10 15:22:07 rpi flashmq[15117]: [2025-11-10 15:22:07.400] [ERROR] [main] Setting ulimit nofile failed: 'Operation not perm>
Nov 10 15:22:07 rpi flashmq[15117]: [2025-11-10 15:22:07.400] [NOTICE] [main] Adding timers
Nov 10 15:22:07 rpi flashmq[15117]: [2025-11-10 15:22:07.400] [NOTICE] [main] 1 threads specified by 'thread_count'.
Nov 10 15:22:07 rpi flashmq[15117]: [2025-11-10 15:22:07.400] [NOTICE] [main] Starting FlashMQ version 1.23.2, release build w>
Nov 10 15:22:07 rpi flashmq[15117]: [2025-11-10 15:22:07.400] [NOTICE] [main] Loading auth plugin /v/u/libexec/flashmq/libflas>
Nov 10 15:22:07 rpi flashmq[15117]: /v/u/libexec/flashmq/libflashmq-dbus-plugin.so: wrong ELF class: ELFCLASS32
Nov 10 15:22:07 rpi systemd[1863]: flashmq.service: Main process exited, code=exited, status=1/FAILURE
Nov 10 15:22:07 rpi systemd[1863]: flashmq.service: Failed with result 'exit-code'
```

And finally if I load the armhf binary (`/v/u/bin/flashmq` instead of `/usr/bin/flashmq`) it starts>
```
ExecStart=/v/u/bin/flashmq --config-file /run/user/%U/flashmq.conf
```

Now this will probably only work on armhf and arm64, otherwise qemu would have to be involved. On armhf it's not required to use /v/u/bin/flashmq since the compiled one can likely load the armhf plugin but on arm64 (assuming 4k pages - so boot the v8 kernel on raspi5) the plugin doesn't load from an arm64 binary.
What's the best way to solve this? Wrapper script to decide on which flashmq to start?